### PR TITLE
Remove code that had warnings; test on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ sudo: false
 python:
   - "2.7"
   - "3.6"
+# Enable 3.7 without globally enabling sudo and dist: xenial for
+# other build jobs
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial
+      sudo: true
 
 # whitelist
 branches:

--- a/src/numkit/fitting.py
+++ b/src/numkit/fitting.py
@@ -214,7 +214,7 @@ class FitLin(FitFunc):
         return "<FitLin"+str(self.parameters)+">"
 
 class FitGauss(FitFunc):
-    """y = f(x) = p[2] * 1/sqrt(2*pi*p[1]**2) * exp(-(x-p[0])**2/(2*p[1]**2))
+    r"""y = f(x) = p[2] * 1/sqrt(2*pi*p[1]**2) * exp(-(x-p[0])**2/(2*p[1]**2))
 
     Fits an un-normalized gaussian (height scaled with parameter p[2]).
 

--- a/src/numkit/integration.py
+++ b/src/numkit/integration.py
@@ -185,7 +185,7 @@ def _trapz_2pt_error2(dy1, dy2, dx):
     For errors dy1 and dy2 and spacing dx."""
     return (0.5*dx)**2 * (dy1**2 + dy2**2)
 
-def _trapz_error2(dy,start,stop,x,dx):
+def _trapz_error2(dy,start,stop,x,dx,axis):
     # not tested
     nd = len(dy.shape)
     if start is None:

--- a/src/numkit/observables.py
+++ b/src/numkit/observables.py
@@ -97,14 +97,14 @@ class QuantityWithError(object):
         self.covariance = {self.qid: self.variance} # record covariances with other
         self.confidence = kwargs.pop('confidence', 0.99)   # for comparisons/not used yet
 
-    def error():
+    @property
+    def error(self):
         """Error of a quantity as sqrt of the variance."""
-        def fget(self):
-            return numpy.sqrt(self.variance)
-        def fset(self, x):
-            self.variance = x*x
-        return locals()
-    error = property(**error())
+        return numpy.sqrt(self.variance)
+
+    @error.setter
+    def error(self, x):
+        self.variance = x*x
 
     def isSame(self, other):
         """Check if *other* is 100% correlated with *self*.

--- a/src/numkit/tests/test_timeseries.py
+++ b/src/numkit/tests/test_timeseries.py
@@ -26,6 +26,7 @@ class TestRegularizedFunction(object):
         assert len(X) == bins
         assert_almost_equal(np.max(Y), np.max(data[1]))
 
+    @pytest.mark.filterwarnings("ignore:tcorrel")
     @pytest.mark.parametrize("func", (
         "rms_histogrammed_function",
         "mean_histogrammed_function",
@@ -46,6 +47,17 @@ class TestRegularizedFunction(object):
         assert len(X) == bins
         # assert_almost_equal(np.max(Y), np.max(data[1]))
         # add test for Y data (but has randomness)
+
+    @pytest.mark.parametrize("func", (
+        "error_histogrammed_function",
+        "tc_histogrammed_function",
+        ))
+    @pytest.mark.parametrize("bins", [1000, 10000])
+    def test_func_warns(self, func, data, bins):
+        function = getattr(numkit.timeseries, func)
+        with pytest.warns(numkit.LowAccuracyWarning):
+            Y, X = function(data[0], data[1], bins=bins)
+
 
 @pytest.mark.parametrize('window', (
     'flat', 'hanning', 'hamming', 'bartlett', 'blackman'))

--- a/src/numkit/timeseries.py
+++ b/src/numkit/timeseries.py
@@ -143,7 +143,7 @@ def tcorrel(x, y, nstep=100, debug=False):
         wmsg = "tcorrel(): Only %d datapoints for the chosen nstep=%d; " \
             "ACF will possibly not be accurate." % (len(_y), nstep)
         warnings.warn(wmsg, category=LowAccuracyWarning)
-        logger.warn(wmsg)
+        logger.warning(wmsg)
 
     acf = autocorrelation_fft(_y, normalize=False)
     try:


### PR DESCRIPTION
This PR should deal with all the warnings that were given. It also has Travis test with Python 3.7 as well.

A doc string is made a raw string because of some LaTeX code in it (warning about invalid escape sequence).

A function is given an argument that it was missing.

The decorator syntax for declaring a property is used (previously raised an error when running pytest, but it seemed to work in iPython, so I'm not sure if it was really an issue).

Use `logging.warning` instead of the deprecated `logging.warn`.

Ignore `LowAccuracyWarning` in a large parameterized test, but then add a test to make sure the warning is issued in those cases. This could be [done a bit more efficiently](https://docs.pytest.org/en/latest/example/parametrize.html#parametrizing-conditional-raising), but this method seemed more concise.

I noticed some of these warnings when working on GromacsWrapper, so I thought I could take care of some of them.