### PR TITLE
python 2/3 compatibility changes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,7 +8,7 @@ hacked together by Oliver Beckstein.
 
 Any person contributing to the code of numkit (as evidenced by
 commits to the repository) should be listed in this file under the
-year of their first commit. GitHub handle is optional.
+year of their first commit. GitHub handle in parentheses is optional.
 
 
 2009
@@ -26,6 +26,11 @@ year of their first commit. GitHub handle is optional.
 ----
 
 - Max Linke (@kain88-de)
+
+2019
+----
+
+- Thomas Heavey (@theavey)
 
 
 We gratefully acknowledge code fixes contributed by

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,11 @@
  CHANGELOG for numkit
 ======================
 
+2021-07-??      1.2.0
+theavey, orbeckst
+
+* supports Python 2.7 and Python 3.6 - 3.9 (issues #11, #12)
+
 
 2018-08-08      1.1.2
 orbeckst

--- a/src/numkit/integration.py
+++ b/src/numkit/integration.py
@@ -17,6 +17,11 @@ from scipy.integrate.quadrature import tupleset
 
 import logging
 logger = logging.getLogger("numkit.integration")
+# monkey patch old logger (warn is deprecated but warning does
+# not exist in 2.7) --- remove when we drop Python 2.7
+if not hasattr(logger, "warning"):
+    logger.warning = logger.warn
+
 
 def simps_error(dy, x=None, dx=1, axis=-1, even='avg'):
     """Error on integral evaluated with `Simpson's rule`_ from errors of points, *dy*.

--- a/src/numkit/integration.py
+++ b/src/numkit/integration.py
@@ -12,8 +12,15 @@
 """
 
 import numpy
-import scipy.integrate
-from scipy.integrate.quadrature import tupleset
+
+try:
+    from scipy.integrate.quadrature import tupleset
+except ImportError:
+    # from https://github.com/scipy/scipy/blob/v1.1.0/scipy/integrate/quadrature.py
+    def tupleset(t, i, value):
+        l = list(t)
+        l[i] = value
+        return tuple(l)
 
 import logging
 logger = logging.getLogger("numkit.integration")

--- a/src/numkit/tests/test_integration.py
+++ b/src/numkit/tests/test_integration.py
@@ -10,10 +10,12 @@
 ====================================
 
 """
+import pytest
 
-import numkit.integration
 import numpy
 from numpy.testing import assert_equal, assert_almost_equal
+
+import numkit.integration
 
 class Test_simps_error(object):
     # special case with constant spacing and constant error (=1.0) so
@@ -87,4 +89,10 @@ class Test_simps_error(object):
         assert_almost_equal(err, 2.7613402542968153, err_msg="Simps error for un-even spacing")
 
 
+def test_uneven_spacing():
+    # simple regression test
+    DY = numpy.array([0.1, 0.2, 0.1, 0.2, 1.0])
+    X = numpy.array([-1, 0, 2, 2.5, 5])
+    err = numkit.integration.simps_error(DY, x=X)
+    assert err == pytest.approx(0.7632168761236874)
 

--- a/src/numkit/timeseries.py
+++ b/src/numkit/timeseries.py
@@ -12,8 +12,13 @@ import scipy.integrate
 import scipy.stats
 
 import warnings
+
 import logging
 logger = logging.getLogger("numkit.timeseries")
+# monkey patch old logger (warn is deprecated but warning does
+# not exist in 2.7) --- remove when we drop Python 2.7
+if not hasattr(logger, "warning"):
+    logger.warning = logger.warn
 
 from numkit import LowAccuracyWarning
 


### PR DESCRIPTION
- address #12 (logger.warning) and #11 (changes in scipy.integrate)
- test all supported python versions (under Linux)